### PR TITLE
Configurable Context Handler

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=99

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # flasql
 
-Basic flask views to provide endpoints for graphql queries, and an
-interactive graphql interface.
+Basic flask views to provide endpoints for graphql queries, and an interactive graphql interface.
 
 
 ### GraphQLView
@@ -12,7 +11,7 @@ Keyword Arguments
 - `error_handler` (optional, default: no-op) a function that takes two kwargs, `error` which is the specific error, and `params` which are the parameters that came into the request.
 - `result_class` (optional, default:`GraphQLResult`) a class that conforms to the same interface of `GraphQLResult`
 - `enable_graphiql` (default: True) determines whether or not the GraphiQL GUI will be available.
-- `context_handler` (optional, default: no-op) a fn which will return a dictionary of additional context to pass into the query being executed, ie the current user.
+- `context_factory` (optional, default: no-op) a factory which will return a dictionary of additional context to pass into the query being executed, ie the current user. The result of this fn [must be iterable](https://docs.python.org/2/glossary.html#term-iterable) because `dict()` is called on the result that is passed to Graphene.
 
 ### Example Sentry Error Handler
 
@@ -29,7 +28,7 @@ def sentry_error_handler(error, params):
 This will pass `auth` through to the Graphene resolvers:
 
 ```python
-def context_handler():
+def context_factory():
     """
     Called just prior to executing a query against the schema.
     The result of this (dict) is sent along with the query as the `context`.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ interactive graphql interface.
 Keyword Arguments
 
 - `schema` a graphene schema to handle the GraphQL queries
-- `error_handler` a function that takes two kwargs, `error` which is the specific error, and `params` which are the parameters that came into the request.
+- `error_handler` (optional, default: no-op) a function that takes two kwargs, `error` which is the specific error, and `params` which are the parameters that came into the request.
 - `result_class` (optional, default:`GraphQLResult`) a class that conforms to the same interface of `GraphQLResult`
 - `enable_graphiql` (default: True) determines whether or not the GraphiQL GUI will be available.
-
+- `context_handler` (optional, default: no-op) a fn which will return a dictionary of additional context to pass into the query being executed, ie the current user.
 
 ### Example Sentry Error Handler
 
@@ -24,3 +24,22 @@ def sentry_error_handler(error, params):
 ```
 
 
+### Example Context Handler
+
+This will pass `auth` through to the Graphene resolvers:
+
+```python
+def context_handler():
+    """
+    Called just prior to executing a query against the schema.
+    The result of this (dict) is sent along with the query as the `context`.
+
+    Useful for attaching high-level things like the current user, etc...
+
+    """
+    auth = flask.g.get('auth')
+
+    return {
+        'auth': auth,
+    }
+```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest
 flake8
+graphene

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,51 @@
+import pytest
+
+import graphene
+import flask
+
+from flasql.views import GraphQLView
+
+
+class Query(graphene.ObjectType):
+    debug = graphene.String()
+
+    def resolve_debug(self, args, context, info):
+        return 'Hi from GraphQL'
+
+
+def create_graphql_view(**kwargs):
+    schema = kwargs.pop('schema')
+
+    kwargs.update({
+        'schema': schema,
+        'enable_graphiql': True,
+    })
+
+    return GraphQLView.as_view('graphql', **kwargs)
+
+
+def create_app(**kwargs):
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    app.add_url_rule('/graphql', view_func=create_graphql_view(**kwargs))
+
+    return app
+
+
+def create_schema():
+    return graphene.Schema(
+        query=Query,
+    )
+
+
+@pytest.fixture()
+def app():
+    """
+    Supplies a basic Flask app with a graphene schema
+    mounted inside the flasql view at /graphql.
+
+    """
+    app = create_app(schema=create_schema())
+    with app.test_request_context():
+        yield app

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,8 @@ import json
 
 from flasql import views
 
+from tests.fixtures import app # noqa
+
 
 class MockLocation(object):
     def __init__(self, line, column):
@@ -23,6 +25,7 @@ class MockError(object):
 def test_format_error_no_details():
     e = MockError()
     formatted = views.format_error(e)
+
     assert formatted['message'] == 'string representation'
     assert 'locations' not in formatted
 
@@ -30,6 +33,7 @@ def test_format_error_no_details():
 def test_format_error_with_message():
     e = MockError(message='bailed out')
     formatted = views.format_error(e)
+
     assert formatted['message'] == 'bailed out'
     assert 'locations' not in formatted
 
@@ -38,6 +42,7 @@ def test_format_error_with_one_location():
     locations = [MockLocation(3, 42)]
     e = MockError(message='bailed out', locations=locations)
     formatted = views.format_error(e)
+
     assert formatted['message'] == 'bailed out'
     assert len(formatted['locations']) == 1
     assert formatted['locations'] == [{'line': 3, 'column': 42}]
@@ -47,6 +52,7 @@ def test_format_error_with_two_locations():
     locations = [MockLocation(3, 42), MockLocation(7, 57)]
     e = MockError(message='bailed out', locations=locations)
     formatted = views.format_error(e)
+
     assert formatted['message'] == 'bailed out'
     assert len(formatted['locations']) == 2
     assert formatted['locations'] == [
@@ -55,10 +61,11 @@ def test_format_error_with_two_locations():
     ]
 
 
-def test_graphqlresult_to_response():
+def test_graphqlresult_to_response(app): # noqa
     result = views.GraphQLResult({'foo': 'bar'})
     resp = result.to_response()
     data = json.loads(resp.data)
+
     assert data == {'foo': 'bar'}
     assert resp.status_code == 200
     assert resp.mimetype == 'application/json'


### PR DESCRIPTION
Graphene provides a concept called `context` which is a dictionary of data that is threaded through the traversal of query execution. [Docs.](http://docs.graphene-python.org/en/latest/execution/execute/#context)

This PR enables the capability to define a `context_handler` function that is called just prior to the query execution. The result of the function, which should be a dictionary, is passed into the execution so that in graphene resolvers it is available under the `context` argument.

### Example

Imagine a scenario where a User's ID is attached as the `X-User-ID` header on each request. We would like to access this as part of the `context` in a Graphene resolver so that we can request data that is specific to the user who is currently logged in.

```python
from flask import request

def context_factory():
    user_id = request.headers.get('X-User-ID')
    return {
        'user_id': user_id
    }
```

And when we define our view and hook it into the Flask application:

```python
graphql_view = GraphQLView.as_view('graphql', schema=schema,
                                              enable_graphiql=True,
                                              context_factory=context_factory)
```

Now we can access our `user_id` within a Graphene resolver:

```python
from database import User, Friend

def resolve_my_online_friends(obj, args, context, info):
    user_id = context.get('user_id')
    
    me = User.get(id=user_id)
    friends = Friend.find_for_user(me)

    return friends
```
