### PR TITLE
Allow ValidationError, AssertionError, GraphQLSyntaxError, ValueError

### DIFF
--- a/flasql/views.py
+++ b/flasql/views.py
@@ -18,7 +18,7 @@ def format_error(error):
     """
     formatted_error = {"message": "Oops! Something went wrong!"}
 
-    if isinstance(error, (ValidationError, AssertionError, GraphQLSyntaxError, ValueError)):
+    if isinstance(error, (ValidationError, GraphQLSyntaxError)):
         formatted_error["message"] = str(error)
     elif "ENVIRONMENT" in os.environ and\
             (os.environ["ENVIRONMENT"] == "development" or os.environ["ENVIRONMENT"] == "test"):

--- a/flasql/views.py
+++ b/flasql/views.py
@@ -7,6 +7,8 @@ from flask.views import MethodView
 
 from flasql import graphiql
 import os
+from pydantic import ValidationError
+from graphql import GraphQLSyntaxError
 
 
 def format_error(error):
@@ -15,20 +17,23 @@ def format_error(error):
     https://github.com/graphql-python/graphql-core/blob/master/graphql/error/format_error.py
     """
     formatted_error = {"message": "Oops! Something went wrong!"}
-    if "ENVIRONMENT" in os.environ:
-        if (
-            os.environ["ENVIRONMENT"] == "development"
-            or os.environ["ENVIRONMENT"] == "test"
-        ):
-            formatted_error = {
-                "message": error.message if hasattr(error, "message") else str(error)
-            }
 
-            if hasattr(error, "locations") and error.locations is not None:
-                formatted_error["locations"] = [
-                    {"line": loc.line, "column": loc.column} for loc in error.locations
-                ]
+    if isinstance(error, (ValidationError, AssertionError, GraphQLSyntaxError, ValueError)):
+        formatted_error["message"] = str(error)
+    elif "ENVIRONMENT" in os.environ and (os.environ["ENVIRONMENT"] == "development" or os.environ["ENVIRONMENT"] == "test"):
+        formatted_error = {
+            "message": error.message if hasattr(error, "message") else str(error)
+        }
+
+        if hasattr(error, "locations") and error.locations is not None:
+            formatted_error["locations"] = [
+                {"line": loc.line, "column": loc.column} for loc in error.locations
+            ]
+
     return formatted_error
+
+
+
 
 
 class GraphQLResult(object):

--- a/flasql/views.py
+++ b/flasql/views.py
@@ -20,7 +20,8 @@ def format_error(error):
 
     if isinstance(error, (ValidationError, AssertionError, GraphQLSyntaxError, ValueError)):
         formatted_error["message"] = str(error)
-    elif "ENVIRONMENT" in os.environ and (os.environ["ENVIRONMENT"] == "development" or os.environ["ENVIRONMENT"] == "test"):
+    elif "ENVIRONMENT" in os.environ and\
+            (os.environ["ENVIRONMENT"] == "development" or os.environ["ENVIRONMENT"] == "test"):
         formatted_error = {
             "message": error.message if hasattr(error, "message") else str(error)
         }
@@ -31,9 +32,6 @@ def format_error(error):
             ]
 
     return formatted_error
-
-
-
 
 
 class GraphQLResult(object):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest
 flake8
 graphene
 mock
+pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask>=0.12.0
+graphene
+pydantic

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -126,28 +126,12 @@ def test_graphqlresult_to_response(app):  # noqa
 
 
 @mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
-def test_format_error_handles_assertionerror(monkeypatch):
-    formatted = views.format_error(AssertionError("AssertionError occurred"))
-
-    assert formatted["message"] == "AssertionError occurred"
-    assert "locations" not in formatted
-
-
-@mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
 def test_format_error_handles_graphqlsyntaxerror(monkeypatch):
     source = Source("GraphQLSyntaxError occurred")
     error = GraphQLSyntaxError(source, position=0, description="GraphQLSyntaxError occurred")
     formatted = views.format_error(error)
 
     assert formatted["message"] == str(error)
-    assert "locations" not in formatted
-
-
-@mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
-def test_format_error_handles_valueerror(monkeypatch):
-    formatted = views.format_error(ValueError("ValueError occurred"))
-
-    assert formatted["message"] == "ValueError occurred"
     assert "locations" not in formatted
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,6 +4,13 @@ from flasql import views
 import mock
 import os
 from tests.fixtures import app  # noqa
+from graphql import GraphQLSyntaxError
+from pydantic import ValidationError, BaseModel
+from graphql.language.source import Source
+
+
+class Model(BaseModel):
+    name: str
 
 
 class MockLocation(object):
@@ -21,6 +28,10 @@ class MockError(object):
 
     def __str__(self):
         return "string representation"
+
+
+class UnexpectedError(Exception):
+    pass
 
 
 @mock.patch.dict(os.environ, {"ENVIRONMENT": "development"})
@@ -112,3 +123,45 @@ def test_graphqlresult_to_response(app):  # noqa
     assert data == {"foo": "bar"}
     assert resp.status_code == 200
     assert resp.mimetype == "application/json"
+
+@mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
+def test_format_error_handles_assertionerror(monkeypatch):
+    formatted = views.format_error(AssertionError("AssertionError occurred"))
+
+    assert formatted["message"] == "AssertionError occurred"
+    assert "locations" not in formatted
+
+
+@mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
+def test_format_error_handles_graphqlsyntaxerror(monkeypatch):
+    source = Source("GraphQLSyntaxError occurred")
+    error = GraphQLSyntaxError(source, position=0, description="GraphQLSyntaxError occurred")
+    formatted = views.format_error(error)
+
+    assert formatted["message"] == str(error)
+    assert "locations" not in formatted
+
+
+@mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
+def test_format_error_handles_valueerror(monkeypatch):
+    formatted = views.format_error(ValueError("ValueError occurred"))
+
+    assert formatted["message"] == "ValueError occurred"
+    assert "locations" not in formatted
+
+
+def test_format_error_handles_unexpected_errors(monkeypatch):
+    formatted = views.format_error(UnexpectedError("Unexpected error occurred"))
+
+    assert formatted["message"] == "Oops! Something went wrong!"
+    assert "locations" not in formatted
+
+@mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
+def test_format_error_handles_validationerror():
+    try:
+        Model(name=None)  # This will raise a ValidationError
+    except ValidationError as e:
+        formatted = views.format_error(e)
+        assert "1 validation error for Model" in formatted["message"]
+        assert "none is not an allowed value" in formatted["message"]
+        assert "locations" not in formatted

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -124,6 +124,7 @@ def test_graphqlresult_to_response(app):  # noqa
     assert resp.status_code == 200
     assert resp.mimetype == "application/json"
 
+
 @mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
 def test_format_error_handles_assertionerror(monkeypatch):
     formatted = views.format_error(AssertionError("AssertionError occurred"))
@@ -155,6 +156,7 @@ def test_format_error_handles_unexpected_errors(monkeypatch):
 
     assert formatted["message"] == "Oops! Something went wrong!"
     assert "locations" not in formatted
+
 
 @mock.patch.dict(os.environ, {"ENVIRONMENT": "live"})
 def test_format_error_handles_validationerror():


### PR DESCRIPTION
ValueError and TypeError are automatically converted to ValidationError by pydantic.
For safety we should only pass through GraphQLSyntaxError and ValidationError for now. 

We can do more  evaluation later for other error types